### PR TITLE
fix(content): correct C4 publish date to 2026-06-26

### DIFF
--- a/src/content/posts/context-limits-design-constraint/index.mdx
+++ b/src/content/posts/context-limits-design-constraint/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "How Context Limits Changed the Way I Build with AI"
 description: "I was getting inconsistent answers and the AI kept forgetting what we'd built. Here's how I stopped fighting context limits and started designing around them."
-date: 2026-07-01
+date: 2026-06-26
 category: ai-development
 tags: ["ai-collaboration", "context-windows", "claude", "productivity", "workflow"]
 author: richard-muffler


### PR DESCRIPTION
## Summary

- Corrects the `date` frontmatter on the C4 article (*How Context Limits Changed the Way I Build with AI*) from `2026-07-01` to `2026-06-26`
- The article was already live on deploy because Astro has no date-gated publishing — the July 1 date was wrong metadata, not a scheduling mechanism

## Context

Astro is a static site generator. Every post in `src/content/posts/` goes live on the next build/deploy regardless of its `date` field. Going forward, scheduling is handled by merging the PR on the intended publish date (Option 1 — branch-based), not by setting a future date in frontmatter.

## Test plan

- [ ] Confirm article shows `June 26, 2026` on the blog listing and post page after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)