### PR TITLE
chore(security): resolve Semgrep blocker

### DIFF
--- a/BLOCKERS.md
+++ b/BLOCKERS.md
@@ -11,8 +11,8 @@
 |---|---|---|---|---|---|
 | 1 | ~~GitHub repository not yet created~~ | ~~All of Phase 1~~ | Richard | 2026-06-22 | ✅ Resolved |
 | ~~2~~ | ~~probl.me DNS: CNAME needs to point to rustymuffler.github.io~~ | ~~M1.14~~ | Richard | 2026-06-22 | ✅ Resolved |
-| 3 | Aikido API key not yet configured | SECURITY_SCANNING.md — Tool 1 (Aikido) | Richard | 2026-06-22 | ⬜ Not started |
-| 4 | Semgrep App Token not yet configured | SECURITY_SCANNING.md — Tool 2 + CI | Richard | 2026-06-22 | ⬜ Not started |
+| 3 | Aikido plugin not yet installed in Claude Code | SECURITY_SCANNING.md — Tool 1 (Aikido) | Richard | 2026-06-22 | ⬜ Not started — run `/plugin marketplace add aikido` in a Claude Code session |
+| ~~4~~ | ~~Semgrep App Token not yet configured~~ | ~~SECURITY_SCANNING.md — Tool 2 + CI~~ | Richard | 2026-06-22 | ✅ Resolved |
 | 5 | Supabase account + project not yet created | M3.17 — Umami analytics database | Richard | 2026-06-22 | ⬜ Not started |
 | 6 | Vercel account not yet created | M3.19 — Umami analytics hosting | Richard | 2026-06-22 | ⬜ Not started |
 | 7 | Umami data-website-id not yet generated | M3.22 — Tracking script in Layout.astro | Richard | 2026-06-22 | 🔑 Waiting on M3.21 (Umami deploy) |
@@ -25,6 +25,7 @@
 | # | Blocker | Resolved Date | Resolution |
 |---|---|---|---|
 | 1 | GitHub repository not yet created | 2026-06-23 | Repo transitioned from old Jekyll resume to probl.me Astro project. All governance docs committed to `main`. Branch renamed from `master` to `main`. |
+| 4 | Semgrep App Token not yet configured | 2026-06-26 | `SEMGREP_APP_TOKEN` added to rustymuffler/problme repo secrets — reused from Celly project (account-level token). |
 
 ---
 

--- a/BLOCKERS.md
+++ b/BLOCKERS.md
@@ -11,7 +11,7 @@
 |---|---|---|---|---|---|
 | 1 | ~~GitHub repository not yet created~~ | ~~All of Phase 1~~ | Richard | 2026-06-22 | ✅ Resolved |
 | ~~2~~ | ~~probl.me DNS: CNAME needs to point to rustymuffler.github.io~~ | ~~M1.14~~ | Richard | 2026-06-22 | ✅ Resolved |
-| 3 | Aikido plugin not yet installed in Claude Code | SECURITY_SCANNING.md — Tool 1 (Aikido) | Richard | 2026-06-22 | ⬜ Not started — run `/plugin marketplace add aikido` in a Claude Code session |
+| ~~3~~ | ~~Aikido plugin not yet installed in Claude Code~~ | ~~SECURITY_SCANNING.md — Tool 1 (Aikido)~~ | Richard | 2026-06-22 | ✅ Resolved |
 | ~~4~~ | ~~Semgrep App Token not yet configured~~ | ~~SECURITY_SCANNING.md — Tool 2 + CI~~ | Richard | 2026-06-22 | ✅ Resolved |
 | 5 | Supabase account + project not yet created | M3.17 — Umami analytics database | Richard | 2026-06-22 | ⬜ Not started |
 | 6 | Vercel account not yet created | M3.19 — Umami analytics hosting | Richard | 2026-06-22 | ⬜ Not started |
@@ -26,6 +26,7 @@
 |---|---|---|---|
 | 1 | GitHub repository not yet created | 2026-06-23 | Repo transitioned from old Jekyll resume to probl.me Astro project. All governance docs committed to `main`. Branch renamed from `master` to `main`. |
 | 4 | Semgrep App Token not yet configured | 2026-06-26 | `SEMGREP_APP_TOKEN` added to rustymuffler/problme repo secrets — reused from Celly project (account-level token). |
+| 3 | Aikido plugin not yet installed in Claude Code | 2026-06-26 | Installed via `/plugin install aikido@claude-plugins-official`; authenticated via `/aikido:setup`. Account-level — covers all Claude Code projects. |
 
 ---
 

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -162,7 +162,7 @@ These invariants are tracked across all phases. The Code Reviewer Agent checks f
 | C1 | Writing a spec your AI agent can actually follow | pm-craft | ⬜ Queued | TBD |
 | C2 | How I built a fully automated content pipeline with Claude agents (and what broke first) | ai-development | ⬜ Queued | TBD |
 | C3 | Multi-agent workflows without an orchestration framework: the AGENTS.md approach | ai-development | ⬜ Queued | TBD |
-| C4 | Context limits as a design constraint: how handoff documents changed the way I build | ai-development | ⬜ Queued | TBD |
+| C4 | How Context Limits Changed the Way I Build with AI | ai-development | ✅ Published | 2026-06-26 |
 | C5 | Scheduled Claude agents: setting up autonomous loops that don't need babysitting | ai-development | ⬜ Queued | TBD |
 | C6 | Astro on GitHub Pages in 2026: what the docs don't tell you | tech-tools | ⬜ Queued | TBD |
 | C7 | Why I SHA-pin every GitHub Action and how I automate keeping them current | tech-tools | ⬜ Queued | TBD |

--- a/SECURITY_SCANNING.md
+++ b/SECURITY_SCANNING.md
@@ -375,7 +375,7 @@ Gaps to be aware of:
 
 | Tool | Status |
 |---|---|
-| Aikido | ⬜ Not yet configured |
+| Aikido | ⬜ Not yet configured — install via `/plugin marketplace add aikido` in Claude Code (account-level; covers all projects once installed) |
 | Semgrep | ✅ Operational 2026-06-25 — installed via pip (`semgrep@1.168.0`); full `auto` scan run on `feat/astro-foundation` pre-PR: 0 findings in `src/` and `.github/`; 8 findings in `design_handoff_blog_site/support.js` (vendor design-preview runtime, not shipped to production — see Semgrep note in Accepted Risk) |
 | rl-protect-skills | ✅ Operational 2026-06-24 — used to scan `@astrojs/check@0.9.9` + `typescript@6.0.3` before install; one GOVERNANCE FAIL acknowledged by Richard (see Accepted Risk Log) |
 | Gitleaks (pre-commit) | ✅ Installed 2026-06-24 — `.git/hooks/pre-commit` using Gitleaks 8.30.1; `.gitleaks.toml` with allowlist |

--- a/SECURITY_SCANNING.md
+++ b/SECURITY_SCANNING.md
@@ -375,7 +375,7 @@ Gaps to be aware of:
 
 | Tool | Status |
 |---|---|
-| Aikido | ⬜ Not yet configured — install via `/plugin marketplace add aikido` in Claude Code (account-level; covers all projects once installed) |
+| Aikido | ✅ Operational 2026-06-26 — installed via `/plugin install aikido@claude-plugins-official`; authenticated via `/aikido:setup`. Account-level — active across all Claude Code projects. |
 | Semgrep | ✅ Operational 2026-06-25 — installed via pip (`semgrep@1.168.0`); full `auto` scan run on `feat/astro-foundation` pre-PR: 0 findings in `src/` and `.github/`; 8 findings in `design_handoff_blog_site/support.js` (vendor design-preview runtime, not shipped to production — see Semgrep note in Accepted Risk) |
 | rl-protect-skills | ✅ Operational 2026-06-24 — used to scan `@astrojs/check@0.9.9` + `typescript@6.0.3` before install; one GOVERNANCE FAIL acknowledged by Richard (see Accepted Risk Log) |
 | Gitleaks (pre-commit) | ✅ Installed 2026-06-24 — `.git/hooks/pre-commit` using Gitleaks 8.30.1; `.gitleaks.toml` with allowlist |


### PR DESCRIPTION
## Summary

- `SEMGREP_APP_TOKEN` added to repo secrets — reused from Celly (account-level token, works across all projects)
- Semgrep CI job in `security.yml` is now fully operational
- Updated `BLOCKERS.md`: blocker #4 resolved, blocker #3 (Aikido) clarified — it's a Claude Code plugin install, not an API key
- Updated `SECURITY_SCANNING.md` setup status table

## What's still open

- **Aikido (blocker #3):** Needs `/plugin marketplace add aikido` run once in a Claude Code session. Account-level — no per-repo config needed after that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)