### PR TITLE
feat(seo): add Google Search Console verification meta tag (M3.16)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -44,6 +44,9 @@ const siteUrl = 'https://probl.me';
   <meta name="twitter:description" content={description} />
   <meta name="twitter:image"       content={`${siteUrl}${ogImage}`} />
 
+  <!-- Google Search Console ownership verification -->
+  <meta name="google-site-verification" content="jnYt7upARHlPd6_-vw_aWNOy5obt6s7p0DXAPPnal6M" />
+
   <!-- Feed & sitemap discovery -->
   <link rel="alternate" type="application/rss+xml" title="probl.me RSS feed" href="/rss.xml" />
   <link rel="sitemap" href="/sitemap-index.xml" />


### PR DESCRIPTION
## Summary

- Adds `<meta name="google-site-verification" content="...">` to `Layout.astro` so it appears on every page of the site
- Required for Google to confirm ownership of `https://probl.me` in Search Console

## After merging

1. Wait for GitHub Actions deploy to complete (~2 min)
2. Go to Search Console → click **Verify**
3. Once verified, go to Sitemaps → enter `sitemap-index.xml` → Submit

## Test plan

- [x] `npm run build` passes
- [x] Gitleaks: 0 leaks
- [ ] Verify in Search Console after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)