### PR TITLE
docs(content): require visuals in every blog post, allow stock images

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ To maintain quality and accountability across both tracks, Claude uses a **multi
 | **Interview Agent** | Claude Cowork | Conducts a structured interview with Richard to capture his personal thoughts, firsthand experiences, and opinions on the article topic before any drafting begins | After an article idea is selected; before any research or drafting begins |
 | **Research Agent** | Claude Cowork | Searches the web and technical sources to build a `research-brief.md` for the article: current statistics, relevant documentation, credible external sources to cite, competitive content scan, and counterarguments worth addressing | After Interview Agent completes; before Writer Agent drafts |
 | **Writer Agent** | Claude Cowork | Drafts articles in MDX format following `CONTENT_STANDARDS.md` — 1,200–2,500 words, professional but approachable, written in Richard's voice, weaving in both the interview notes and research brief | After Research Agent delivers the research brief |
-| **Image Creator Agent** | Claude Cowork | Creates a hero image and any in-article images using Claude's native image generation, following `BRAND.md` guidelines | After Writer Agent completes a draft |
+| **Image Creator Agent** | Claude Cowork | Creates a hero image and any in-article images, either via Claude Design generation or by sourcing royalty-free stock images, following `BRAND.md` guidelines | After Writer Agent completes a draft |
 | **SEO Reviewer Agent** | Claude Cowork | Reviews the completed draft for SEO compliance: meta tags, Open Graph, keywords, heading structure, reading level, word count — approves or returns feedback | After Image Creator Agent completes images |
 | **Proofreader Agent** | Claude Cowork | Reviews the SEO-approved draft for natural human-sounding tone, correct grammar, correct punctuation, and prohibited patterns (no em dashes, no banned phrases) — approves or returns specific line-level feedback | After SEO Reviewer Agent approves; before Publisher Agent opens the PR |
 
@@ -176,14 +176,24 @@ When generating article ideas, the Content Strategist Agent must:
 
 ### Image Creator Agent — Image Rules
 
-When creating images:
+Every article must ship with visuals. No article publishes as pure text: at minimum, a hero image plus at least one in-article image (diagram, chart, screenshot, artwork, or photo).
 
-- All images must follow the `BRAND.md` color palette and visual style
+Images may come from either source:
+
+1. **Claude Design generation** — original artwork, diagrams, charts, or illustrations, created natively.
+2. **Royalty-free stock images** — sourced online from libraries that grant free commercial use with no attribution required (e.g., Unsplash, Pexels, Pixabay). Before using a stock image, the Image Creator Agent must confirm the license permits commercial use and redistribution, and record the source URL.
+
+When creating or sourcing images:
+
+- All images must follow the `BRAND.md` color palette and visual style — this applies to stock images too; see `BRAND.md` → Image Standards → Stock Images for the required treatment.
 - Hero images must be 1200×630px (Open Graph dimensions) — this image doubles as the OG image for social sharing
 - In-article images should be relevant, not decorative. Each image must add information or clarify a concept
 - Save images alongside the MDX file: `src/content/posts/[article-slug]/images/`
 - Name images descriptively: `hero.png`, `agent-workflow-diagram.png`, `before-after-component.png`
-- All Claude-generated images must include a frontmatter field: `imageCredit: "AI-generated with Claude"`
+- Set the frontmatter `imageCredit` field to match the actual source:
+  - `imageCredit: "AI-generated with Claude"` — Claude Design generated
+  - `imageCredit: "Stock photo — [Source name], royalty-free"` — sourced stock image, e.g. `"Stock photo — Unsplash, royalty-free"`
+  - `imageCredit: "Personal screenshot"` or `imageCredit: "Personal photo"` — Richard's own material
 
 ### Interview Agent — Interview Process
 

--- a/BRAND.md
+++ b/BRAND.md
@@ -188,11 +188,11 @@ Blog post cards in the listing grid.
 ### Hero Images
 
 - **Dimensions:** 1200×630px (also used as OG image)
-- **Style:** Abstract, conceptual, or illustrative — not stock photo clichés
+- **Style:** Abstract, conceptual, or illustrative — not generic stock photo clichés (handshakes, lightbulbs, stock office scenes). Claude Design generation is the default choice for heroes; a stock photo may be used if it's treated per the Stock Images rules below so it doesn't read as generic
 - **Color palette:** Drawn from the probl.me palette (dark background, blue/teal accents)
 - **Typography in images:** Use Inter if text is included. Keep text to a minimum.
 - **Format:** PNG for Claude-generated images; WebP for photos
-- **Attribution frontmatter:** `imageCredit: "AI-generated with Claude"`
+- **Attribution frontmatter:** `imageCredit: "AI-generated with Claude"` or, for a sourced stock image, `imageCredit: "Stock photo — [Source name], royalty-free"`
 
 ### In-Article Images
 
@@ -200,6 +200,17 @@ Blog post cards in the listing grid.
 - **Diagrams and flowcharts:** Dark background, blue/teal accent colors, clear labels
 - **Screenshots:** Include a thin border (`#2E3147`) to frame light-background screenshots against the dark site
 - **Alt text:** Always descriptive. Describe what the image shows, not what it is.
+- **Minimum:** every article needs at least one in-article image in addition to the hero — no article should publish as a wall of text
+
+### Stock Images
+
+Every blog article must include visuals, and not every image needs to be Claude-generated. Royalty-free stock images are an acceptable source for hero or in-article images alongside Claude Design artwork, diagrams, and charts.
+
+- **Approved sources only:** use libraries that grant free commercial use with no attribution requirement (e.g., Unsplash, Pexels, Pixabay). Confirm the specific image's license before using it, not just the general site policy.
+- **Fit the brand, don't fight it:** avoid generic corporate stock clichés. Prefer photography that is moody, technical, abstract, or texture-driven over posed people-in-an-office shots.
+- **Color treatment required:** if the raw stock image doesn't already sit comfortably in the probl.me dark palette, apply a dark overlay or a blue/teal duotone treatment before using it, so it doesn't look like a bright rectangle dropped onto a dark page.
+- **Record the source:** set `imageCredit: "Stock photo — [Source name], royalty-free"` in frontmatter so the source is traceable.
+- **Same bar as generated images:** descriptive alt text and "must add information, not decorate" both still apply.
 
 ---
 

--- a/CONTENT_STANDARDS.md
+++ b/CONTENT_STANDARDS.md
@@ -166,7 +166,7 @@ tags:
 slug: your-article-slug     # lowercase, hyphens only, keyword-rich
 heroImage: ./images/hero.png
 imageAlt: "A descriptive alt text for the hero image"
-imageCredit: "AI-generated with Claude"   # or "Personal screenshot" or "Personal photo"
+imageCredit: "AI-generated with Claude"   # or "Stock photo — [Source name], royalty-free" or "Personal screenshot" or "Personal photo"
 draft: false                # true = will not publish; false = publishes on build
 featured: false             # true = shown in featured slot on homepage
 ---
@@ -221,10 +221,11 @@ Every article must meet these requirements before the Publisher Agent opens a PR
 
 ### Images
 
-- Every article must have a hero image
+- Every article must have a hero image, plus at least one in-article image — no article ships as pure text
 - Every image must have descriptive alt text (not "image" or "photo" — describe what is shown)
 - Hero image doubles as the OG image (1200×630px)
 - Compress all images before committing (use `astro:assets` optimization or WebP format)
+- Every stock image's royalty-free license must be confirmed before use, with the source recorded in `imageCredit`
 
 ### Internal Linking
 
@@ -299,10 +300,12 @@ Richard's personal content from the interview notes should be distributed throug
 
 ### Step 5: Image Creator Agent — Images
 
-The Image Creator Agent creates:
+The Image Creator Agent creates or sources:
 
 - Hero image (1200×630px, follows `BRAND.md`)
-- Any in-article images replacing Writer Agent's image placeholders
+- At least one in-article image replacing Writer Agent's image placeholders
+
+Every article must ship with a hero image plus at least one in-article visual (diagram, chart, artwork, screenshot, or photo) — no article publishes as pure text. Each image is either generated with Claude Design or sourced as a royalty-free stock image (license confirmed and source recorded — see `AGENTS.md` → Image Creator Agent — Image Rules).
 
 Images are saved to `src/content/posts/[article-slug]/images/` with descriptive names.
 
@@ -383,7 +386,7 @@ If a factual error is found after publishing:
 2. **Interview notes are required.** No article may enter the drafting step without `interview-notes.md`. Richard's personal content must be present and identifiable in the final draft.
 3. **No em dashes.** Never. The Proofreader Agent will reject any draft containing `—`. Rewrite the sentence instead.
 4. **No fabricated quotes.** Every attributed quote must be real and verifiable.
-5. **No unlicensed images.** Claude-generated, personal screenshots, or personal photos only.
+5. **No unlicensed images.** Claude-generated, personal screenshots, personal photos, or confirmed royalty-free stock images only. Every article must include a hero image plus at least one in-article visual.
 6. **[VERIFY] flags must be resolved before publishing.** Never publish an article with unresolved `[VERIFY]` flags.
 7. **SEO checklist must be 100% complete** before the Publisher Agent opens a PR.
 8. **Proofreader must approve** before the Publisher Agent opens a PR.

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -140,7 +140,7 @@ These invariants are tracked across all phases. The Code Reviewer Agent checks f
 3. **No em dashes.** Never. Proofreader Agent rejects any draft containing `—`. Rewrite the sentence.
 4. **Proofreader must approve** before any content PR is opened.
 5. **No fabricated quotes.** Every attributed quote must be real and verifiable.
-6. **No unlicensed images.** Claude-generated, personal screenshots, or personal photos only.
+6. **No unlicensed images.** Claude-generated, personal screenshots, personal photos, or confirmed royalty-free stock images only. Every article must include a hero image plus at least one in-article visual.
 7. **No secrets in source files.** Use environment variables and GitHub Secrets.
 8. **SEO checklist 100% complete before any content PR opens.**
 9. **Lighthouse minimums:** Performance ≥ 90, Accessibility ≥ 95, SEO ≥ 95.


### PR DESCRIPTION
## Summary
- Every article must now include a hero image plus at least one in-article visual — no more publishing as pure text
- Images can be Claude Design generations (art, diagrams, charts) or royalty-free stock photos, provided the license is confirmed and the source is recorded in `imageCredit`
- `AGENTS.md`: Image Creator Agent rules expanded to cover stock image sourcing, licensing checks, and the new minimum image count
- `CONTENT_STANDARDS.md`: frontmatter example, Step 5 workflow, SEO Images checklist, and Invariant #5 updated to reflect the new source option and minimum
- `BRAND.md`: new "Stock Images" subsection — approved royalty-free sources, avoiding generic stock clichés, and the color-treatment rule so stock photos still fit the dark palette; hero image guidance updated to allow a treated stock photo as an alternative to Claude-generated artwork
- `MILESTONES.md`: invariant #6 updated to match

## Test plan
- [ ] Docs-only change — no build/runtime impact
- [ ] Next article through the pipeline: confirm the Image Creator Agent either generates art or sources a licensed stock image, and that the SEO Reviewer checks for the minimum image count

🤖 Generated with [Claude Code](https://claude.com/claude-code)