### PR TITLE
chore(deps): add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` for the `github-actions` ecosystem (weekly schedule)
- Closes the gap where every Action is SHA-pinned (per `SECURITY_SCANNING.md`, Checkov `CKV_GHA_1`) but nothing checked for or applied updates
- Going forward, Dependabot opens a PR automatically when a pinned Action has a newer release, updating both the SHA and the `# vX` comment

## Verification
- YAML validated
- `checkov -d .github/ --quiet`: 176 passed, 0 failed
- Gitleaks pre-commit hook: no leaks found

## Test plan
- [ ] Merge and confirm Dependabot runs on its weekly schedule (check the Insights → Dependency graph → Dependabot tab for the next scheduled run)
- [ ] Confirm the first automated PR (when one appears) correctly updates a pinned SHA + version comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)