### PR TITLE
chore(security): add OpenSSF Scorecard CI check, correct Checkov claim

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,45 @@
+name: Scorecard supply-chain security
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '30 1 * * 6'  # weekly, Saturdays — matches Dependabot's cadence
+  push:
+    branches: ["main"]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: false
+
+      - name: Upload SARIF artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9  # v3
+        with:
+          sarif_file: results.sarif

--- a/SCORECARD_IMPROVEMENTS.md
+++ b/SCORECARD_IMPROVEMENTS.md
@@ -1,0 +1,59 @@
+# probl.me — OpenSSF Scorecard Improvement Log
+
+> Tracks the real, measured OpenSSF Scorecard score for this repository and what's worth fixing before `publish_results` is flipped to `true` in `.github/workflows/scorecard.yml`.
+> Results are currently **private** (visible only in this repo's Security tab). This file is the source of truth for the decision to eventually go public.
+
+---
+
+## Latest run
+
+- **Date:** 2026-07-12
+- **Overall score:** 6.1 / 10
+- **Commit analyzed:** `e5ba35330388973b4900483481d6e67ae86cf2be`
+- **Method:** `docker run --rm -e GITHUB_AUTH_TOKEN="$(gh auth token)" gcr.io/openssf/scorecard:stable --repo=github.com/rustymuffler/problme --format=json`
+
+## Full breakdown
+
+| Check | Score | Reason |
+|---|---|---|
+| Pinned-Dependencies | 10/10 | All dependencies are pinned |
+| Token-Permissions | 10/10 | Workflows follow least privilege |
+| Dependency-Update-Tool | 10/10 | Dependabot detected |
+| Dangerous-Workflow | 10/10 | No dangerous workflow patterns |
+| CI-Tests | 10/10 | 11/11 merged PRs checked by CI |
+| Maintained | 10/10 | 30 commits in last 90 days |
+| License | 10/10 | License file detected |
+| Binary-Artifacts | 10/10 | No binaries in repo |
+| Vulnerabilities | 9/10 | 1 known vulnerability detected (needs triage, see below) |
+| Branch-Protection | 0/10 | Not enabled on `main` |
+| Security-Policy | 0/10 | No `SECURITY.md` |
+| SAST | 0/10 | Scorecard doesn't recognize a SAST tool running on all commits |
+| Code-Review | 0/10 | 0/14 merged changesets had a human approval |
+| Contributors | 0/10 | 0 contributing orgs (solo project) |
+| CII-Best-Practices | 0/10 | No OpenSSF Best Practices badge |
+| Fuzzing | 0/10 | Not fuzzed |
+| Packaging | N/A (-1) | No packaging workflow (not applicable, static site) |
+| Signed-Releases | N/A (-1) | No releases (not applicable) |
+
+## Actionable before considering public
+
+These are real gaps, not structural artifacts of being a solo project, worth fixing:
+
+1. **Branch-Protection (0/10).** `main` currently has no branch protection rule (`gh api repos/rustymuffler/problme/branches/main/protection` returns 404). Fix: enable "Require a pull request before merging" and "Require status checks to pass" (ci, security, lighthouse) on `main`. Does not require a second human reviewer to still raise this score, that requirement is what would additionally move Code-Review.
+2. **Security-Policy (0/10).** No `SECURITY.md` at repo root. Fix: add one describing how to report a vulnerability (even a simple "email richard.muffler@gmail.com" policy satisfies the check).
+3. **SAST (0/10).** Semgrep already runs in `security.yml`, but Scorecard's SAST check specifically looks for recognized SAST tool signals tied to commits (e.g., SARIF uploads to GitHub code scanning), not just any step named "semgrep" in a workflow. Fix: have the Semgrep step upload SARIF results to GitHub's code scanning (similar to what `scorecard.yml` now does), so Scorecard recognizes it as an active SAST tool.
+4. **Vulnerabilities (9/10).** 1 known vulnerability flagged via OSV. The Scorecard JSON summary doesn't include which one, cross-reference against `SECURITY_SCANNING.md`'s Accepted Risk Log (the `yaml` stack-overflow chain and `@lhci/cli` transitive HIGH finding are the most likely candidates, both already reviewed and accepted as dev-only, zero production attack surface). Needs a follow-up run with more verbose output to confirm which CVE this maps to before calling it fully resolved.
+
+## Structurally low-fixability, not worth chasing right now
+
+These score 0 for reasons tied to being a solo-maintainer project, not real security gaps:
+
+- **Code-Review (0/10).** Requires a second human approving PRs. Richard is the only maintainer, this would require deliberately recruiting a second reviewer for every PR, which isn't realistic right now.
+- **Contributors (0/10).** Requires contributors from multiple organizations. Not applicable to a solo personal project.
+- **CII-Best-Practices (0/10).** Requires manually applying for and completing the separate OpenSSF Best Practices badge program, a real but optional, low-priority initiative, not a quick config fix.
+- **Fuzzing (0/10).** Not meaningfully applicable, probl.me is a static content site with no parser/executable attack surface to fuzz.
+- **Packaging / Signed-Releases (N/A).** Not applicable, this isn't a published package with releases.
+
+## Decision log
+
+- **2026-07-12:** Scorecard workflow added with `publish_results: false`. Decision made to keep results private until the actionable items above (Branch-Protection, Security-Policy, SAST recognition) are addressed, so a future public score reflects genuinely fixed gaps rather than exposing unaddressed ones alongside structural non-issues that could be misread by readers unfamiliar with the checks.

--- a/SECURITY_SCANNING.md
+++ b/SECURITY_SCANNING.md
@@ -27,6 +27,7 @@ Each tool covers a distinct threat category. They are **not redundant** — do n
 | 5 | Trivy | Dependency CVEs (SCA) | After package installs / CI |
 | 6 | Gitleaks | Hardcoded secrets | Pre-commit hook + CI |
 | 7 | Checkov | IaC misconfigurations | When GitHub Actions workflows are written |
+| 8 | OpenSSF Scorecard | Supply-chain hygiene (pinning, token permissions, dangerous workflow patterns, dependency update tooling) | Weekly + on push to `main` + branch protection rule change |
 
 ---
 
@@ -206,13 +207,32 @@ checkov -d . --quiet
 
 **probl.me-specific focus:**
 - GitHub Actions workflow security is the primary concern. Every workflow must be scanned.
-- Pin all third-party GitHub Actions to a specific commit SHA (not just a tag): `uses: actions/checkout@v4` is a tag and can be compromised; `uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683` is pinned.
 - Use `permissions: read-all` at the workflow level and only escalate permissions for the specific job that needs them (e.g., `pages: write` only for the deploy job).
+
+**Correction (2026-07-12):** an earlier version of this section claimed Checkov enforces SHA-pinning of third-party Actions (`uses: actions/checkout@v4` is a tag and can be compromised; the pinned SHA form is required). That was inaccurate. Checkov's actual GitHub Actions checks (`CKV_GHA_1`–`CKV_GHA_7`, `CKV2_GHA_1`) cover unsecure commands, shell injection, curl-with-secrets, netcat usage, cosign attestation, and build parameter isolation, none of them check SHA-pinning. There is an open, stale, never-shipped Checkov feature request for this exact check ([bridgecrewio/checkov#7057](https://github.com/bridgecrewio/checkov/issues/7057)). All Actions in this repo are still pinned to a full commit SHA, that practice is real and verified, it just isn't enforced by Checkov. See Section 8 (OpenSSF Scorecard) for the tool that actually checks this.
 
 **Suppressing false positives:**
 ```yaml
 # checkov:skip=CKV_GHA_1 — reason why this is acceptable
 ```
+
+---
+
+### 8. OpenSSF Scorecard — Supply-Chain Hygiene
+
+**Workflow:** `.github/workflows/scorecard.yml`
+
+**When to run:**
+- Automatically: weekly (Saturdays), on every push to `main`, and on branch protection rule changes
+- No local install needed for CI; can be run locally via the official Docker image for ad hoc checks: `docker run --rm -e GITHUB_AUTH_TOKEN="$(gh auth token)" gcr.io/openssf/scorecard:stable --repo=github.com/rustymuffler/problme --format=json`
+
+**What it catches (that other tools in this stack don't):**
+- Whether third-party Actions are actually pinned to a commit SHA (Checkov does not check this, see the correction in Section 7)
+- Branch protection status, token permission scoping, dangerous workflow patterns, whether a dependency update tool is present, and several other supply-chain hygiene signals across ~18 checks total
+
+**Results handling:** results are uploaded as SARIF to this repo's own Security tab (code scanning alerts) only. `publish_results` is set to `false`, results are **not** published to the public OpenSSF/deps.dev database or exposed as a public badge. This was a deliberate choice (2026-07-12): several Scorecard checks (Code-Review, Contributors, CII-Best-Practices, Fuzzing) score near-zero for a solo-maintainer static site for structural reasons unrelated to actual risk, and publishing before the genuinely actionable gaps are addressed would be a misleading public signal. See `SCORECARD_IMPROVEMENTS.md` for the current score breakdown and what's actually worth fixing before flipping `publish_results` to `true`.
+
+**Static site context:** this is the tool that actually validates the SHA-pinning practice this repo already follows. It complements Checkov (which covers different IaC concerns) rather than replacing it, consistent with the "not redundant" philosophy at the top of this document.
 
 ---
 
@@ -382,7 +402,8 @@ Gaps to be aware of:
 | rl-protect-skills | ✅ Operational 2026-06-24 — used to scan `@astrojs/check@0.9.9` + `typescript@6.0.3` before install; one GOVERNANCE FAIL acknowledged by Richard (see Accepted Risk Log) |
 | Gitleaks (pre-commit) | ✅ Installed 2026-06-24 — `.git/hooks/pre-commit` using Gitleaks 8.30.1; `.gitleaks.toml` with allowlist |
 | Trivy | ✅ Operational 2026-06-25 — installed via winget (`trivy@0.71.2`); filesystem scan of `feat/astro-foundation` at HIGH,CRITICAL: 0 vulnerabilities found in `package-lock.json` (dev deps excluded by default) |
-| Checkov | ✅ Operational 2026-06-25 — installed via pip; run on `.github/workflows/` for `feat/astro-foundation` pre-PR: 180 checks passed, 0 failed (re-verified this session) |
+| Checkov | ✅ Operational 2026-06-25 — installed via pip; run on `.github/workflows/` for `feat/astro-foundation` pre-PR: 180 checks passed, 0 failed (re-verified this session); 200 checks passed, 0 failed after `scorecard.yml` added 2026-07-12 |
+| OpenSSF Scorecard | ✅ Operational 2026-07-12 — `.github/workflows/scorecard.yml` added, weekly + push-to-main + branch-protection-rule triggers, results private (`publish_results: false`). Initial live score: 6.1/10 — see `SCORECARD_IMPROVEMENTS.md` |
 
 Update this table as tools are configured during setup.
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/scorecard.yml`: OpenSSF Scorecard analysis on a weekly schedule, on push to `main`, and on branch protection rule changes. Results are private (`publish_results: false`, SARIF uploaded only to this repo's own Security tab).
- Corrects a factual error in `SECURITY_SCANNING.md`: it previously claimed Checkov enforces SHA-pinning of third-party GitHub Actions. It doesn't, verified locally (`checkov -d .github/ --framework github_actions`), Checkov's actual checks (`CKV_GHA_1`-`CKV_GHA_7`, `CKV2_GHA_1`) cover unrelated concerns. There's an open, unshipped Checkov feature request for this exact check ([bridgecrewio/checkov#7057](https://github.com/bridgecrewio/checkov/issues/7057)).
- Adds `SCORECARD_IMPROVEMENTS.md`: the real, measured score (6.1/10) with a full check-by-check breakdown, separating genuinely actionable gaps (branch protection not enabled, no `SECURITY.md`, Semgrep not recognized as a SAST tool by Scorecard) from checks that score low for structural reasons unrelated to risk (Code-Review, Contributors, CII-Best-Practices, Fuzzing, all expected for a solo-maintainer static site).

## Why now
Written while researching an article on SHA-pinning GitHub Actions. `SECURITY_SCANNING.md` attributed pinning enforcement to Checkov, tracing that claim down turned up that it was never actually true. OpenSSF Scorecard's Pinned-Dependencies check is the real tool for this, so it's added as a new, non-redundant layer rather than patched onto Checkov.

## Verification
- `checkov -d .github/ --quiet`: 200 passed, 0 failed (up from 176 pre-change)
- `/security-review`: no HIGH/MEDIUM findings
- Gitleaks pre-commit hook: no leaks found
- Live Scorecard run against the actual repo (`docker run gcr.io/openssf/scorecard:stable`) confirms Pinned-Dependencies scores 10/10 today

## Test plan
- [ ] Merge and confirm the workflow runs on the next push to `main`
- [ ] Check the Security tab for the SARIF-based code scanning results
- [ ] Revisit `SCORECARD_IMPROVEMENTS.md` once the actionable items are addressed and decide whether to flip `publish_results` to `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)