### PR TITLE
docs: correct content pipeline docs to match real implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,7 +188,8 @@ When creating or sourcing images:
 - All images must follow the `BRAND.md` color palette and visual style — this applies to stock images too; see `BRAND.md` → Image Standards → Stock Images for the required treatment.
 - Hero images must be 1200×630px (Open Graph dimensions) — this image doubles as the OG image for social sharing
 - In-article images should be relevant, not decorative. Each image must add information or clarify a concept
-- Save images alongside the MDX file: `src/content/posts/[article-slug]/images/`
+- **Runtime images** (what the site actually serves) go in `public/assets/posts/[article-slug]/`, referenced in frontmatter/MDX as `/assets/posts/[article-slug]/hero.png`. This is the real, working convention, verified against the content schema and the published articles. **Correction (2026-07-12):** an earlier version of this document said images live at `src/content/posts/[article-slug]/images/`; that path is not served by the site.
+- **Source design files** (editable SVGs, working files) may still be kept alongside the article at `src/content/posts/[article-slug]/images/` for provenance. They are not served directly and are not required, but are worth keeping if the image was hand-built rather than sourced externally.
 - Name images descriptively: `hero.png`, `agent-workflow-diagram.png`, `before-after-component.png`
 - Set the frontmatter `imageCredit` field to match the actual source:
   - `imageCredit: "AI-generated with Claude"` — Claude Design generated

--- a/CONTENT_STANDARDS.md
+++ b/CONTENT_STANDARDS.md
@@ -71,17 +71,19 @@ Every article must follow this structure:
 
 ### Callout Blocks
 
-Use callout blocks sparingly to highlight important notes or warnings. In MDX:
+Use callout blocks sparingly to highlight important notes or warnings. Import the `Callout` component and use it directly, there is no `:::` container syntax support:
 
 ```mdx
-:::note
-This is important context the reader shouldn't miss.
-:::
+import Callout from '../../../components/Callout.astro';
 
-:::warning
-A common mistake to avoid.
-:::
+<Callout type="note">This is important context the reader shouldn't miss.</Callout>
+
+<Callout type="warning">A common mistake to avoid.</Callout>
+
+<Callout type="tip">You can also do this instead.</Callout>
 ```
+
+The relative import path depends on the article's location. From `src/content/posts/[slug]/index.mdx` it is `../../../components/Callout.astro`.
 
 ### Code Blocks
 
@@ -149,38 +151,42 @@ The Proofreader Agent must scan for both `—` and `–` in every draft before a
 
 ## 5. MDX Frontmatter Requirements
 
-Every article file must include complete frontmatter. The Writer Agent fills this out before handing off to the SEO Reviewer Agent.
+Every article file must include complete frontmatter matching the schema defined in `src/content.config.ts`, which is the actual source of truth. Keep this section in sync with that file if the schema ever changes.
+
+**Correction (2026-07-12):** an earlier version of this section described a frontmatter schema that did not match `content.config.ts`, and following it would have broken the build. The schema below is verified against the real implementation.
 
 ```yaml
 ---
 title: "Your Article Title — Clear and Keyword-Rich"
 description: "A 150–160 character description that summarizes the article and includes the primary keyword. This appears in Google and social previews."
-publishDate: 2026-06-25
-updatedDate: 2026-06-25   # Update this if the article is significantly revised
-author: richard-muffler
 category: tech-tools        # pm-craft | ai-development | tech-tools
 tags:
   - astro
   - github-pages
   - static-site
-slug: your-article-slug     # lowercase, hyphens only, keyword-rich
-heroImage: ./images/hero.png
-imageAlt: "A descriptive alt text for the hero image"
+date: 2026-06-25
+readTime: "7 min"           # estimated reading time, matches the site's existing display convention
+heroImage: /assets/posts/[article-slug]/hero.png
 imageCredit: "AI-generated with Claude"   # or "Stock photo — [Source name], royalty-free" or "Personal screenshot" or "Personal photo"
-draft: false                # true = will not publish; false = publishes on build
-featured: false             # true = shown in featured slot on homepage
 ---
 ```
 
 ### Required Fields
 
-All of the following are required. The SEO Reviewer Agent will reject any draft missing these:
-
-`title`, `description`, `publishDate`, `author`, `category`, `tags`, `slug`, `heroImage`, `imageAlt`, `imageCredit`, `draft`
+`title`, `description`, `category`, `tags`, `date`, `readTime`. The Astro build fails outright if any of these are missing or malformed, this is enforced by the Zod schema in `content.config.ts`, not just a style convention.
 
 ### Optional Fields
 
-`updatedDate`, `featured`
+`heroImage`, `imageCredit`.
+
+### Fields that do not exist in the schema
+
+An earlier version of this document referenced `publishDate`, `updatedDate`, `author`, `slug`, `imageAlt`, `draft`, and `featured` as frontmatter fields. None of these exist in the real content collection schema:
+
+- **Slug** is derived automatically from the article's folder name (`src/content/posts/[slug]/index.mdx`), not a frontmatter field.
+- **Author** is hardcoded in the site template, this is a single-author blog, not a frontmatter field.
+- **Alt text** for the hero image is derived automatically from `title`. There is no separate `imageAlt` field. In-article images set their own alt text directly in markdown image syntax (`![descriptive alt text](url)`).
+- **Draft status:** there is no `draft` field or build-time gate. An article is unpublished simply by not existing on `main` yet, the Publisher Agent's draft PR is the real gate. Do not merge an article's PR until it's ready to go live.
 
 ---
 
@@ -234,7 +240,7 @@ Every article must meet these requirements before the Publisher Agent opens a PR
 
 ### External Linking
 
-All external links must include `target="_blank" rel="noopener noreferrer"`.
+**Correction (2026-07-12):** this section previously stated that all external links must include `target="_blank" rel="noopener noreferrer"`, phrased as if it were already enforced. It isn't. Standard markdown link syntax (`[text](url)`) is what's actually used across the site today; external links open in the same tab and carry no `rel` attribute. If opening external links in a new tab is wanted, it needs a site-wide fix (e.g. a rehype plugin such as `rehype-external-links` in `astro.config.mjs`), not something each article handles by hand. Logged as a real follow-up rather than silently dropped.
 
 ---
 

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -85,7 +85,7 @@
 | 3.4 | Set up monthly retrospective scheduled task | ✅ | `probme-monthly-retro` — fires first Monday of month 10am; next run 2026-07-06 — 2026-06-26 |
 | 3.5 | Create `retros/` folder in repository | ✅ | `retros/.gitkeep` committed to main — 2026-06-26 |
 | 3.6 | Define initial content calendar (first 4 articles) | ✅ | First idea batch run 2026-06-26; Richard selected 7 articles — see Content Calendar below |
-| 3.7 | Article 1: Interview → Research → Draft → Review → Proofread → PR | ⬜ | Full end-to-end test of the complete pipeline |
+| 3.7 | Article 1: Interview → Research → Draft → Review → Proofread → PR | ✅ | C7 "Why I SHA-Pin Every GitHub Action" ran the full pipeline end-to-end — PR [#55](https://github.com/rustymuffler/problme/pull/55) open, pending Richard's review/merge — 2026-07-12 |
 | 3.8 | Article 2: Interview → Research → Draft → Review → Proofread → PR | ⬜ | |
 | 3.9 | Article 3: Interview → Research → Draft → Review → Proofread → PR | ⬜ | |
 | 3.10 | Article 4: Interview → Research → Draft → Review → Proofread → PR | ⬜ | |
@@ -165,10 +165,10 @@ These invariants are tracked across all phases. The Code Reviewer Agent checks f
 | C4 | How Context Limits Changed the Way I Build with AI | ai-development | ✅ Published | 2026-06-26 |
 | C5 | Scheduled Claude agents: setting up autonomous loops that don't need babysitting | ai-development | ⬜ Queued | TBD |
 | C6 | Astro on GitHub Pages in 2026: what the docs don't tell you | tech-tools | ⬜ Queued | TBD |
-| C7 | Why I SHA-pin every GitHub Action and how I automate keeping them current | tech-tools | ⬜ Queued | TBD |
+| C7 | Why I SHA-Pin Every GitHub Action (and Automate Updates) | tech-tools | 🔑 PR Open | 2026-07-17 |
 
 **Pipeline status key:** ⬜ Queued → 🔄 Interview → 🔄 Research → 🔄 Draft → 🔄 Review → 🔄 Proofread → 🔑 PR Open → ✅ Published
 
 ---
 
-*Last updated: 2026-06-26 — PM Agent: marked 1.14, 1.15, 2.19, 3.1–3.6 ✅; added Content Calendar with 7 selected articles (session 2026-06-26).*
+*Last updated: 2026-07-12 — PM Agent: C7 ran the full pipeline end-to-end (interview → research → draft → images → SEO review → proofread → draft PR). PR [#55](https://github.com/rustymuffler/problme/pull/55) open for Richard's review. Also merged two supporting infra PRs found while researching C7: [#48](https://github.com/rustymuffler/problme/pull/48) (Dependabot for github-actions) and [#54](https://github.com/rustymuffler/problme/pull/54) (OpenSSF Scorecard, corrected a false Checkov claim in SECURITY_SCANNING.md). No blockers hit; this was the first full validation of M3.7 (Article 1 end-to-end).*


### PR DESCRIPTION
## Summary
Drafting PR #55 (the SHA-pinning article) surfaced several places where `CONTENT_STANDARDS.md` and `AGENTS.md` describe conventions that don't match the actual Astro implementation. Following the old docs as written would have broken the build (confirmed, it did, until fixed in #55).

- **Frontmatter schema** (`CONTENT_STANDARDS.md` Section 5): docs described `publishDate`/`slug`/`author`/`imageAlt`/`draft`/`featured` fields that don't exist in `content.config.ts`. Rewrote to match the real schema and explained where slug, author, alt text, and draft status actually come from instead (folder name, hardcoded template, auto-derived from title, and PR-merge state, respectively).
- **Image path convention** (`AGENTS.md`): docs said `src/content/posts/[slug]/images/`; the real, working convention is `public/assets/posts/[slug]/`, confirmed against the schema and the one published article.
- **Callout syntax** (`CONTENT_STANDARDS.md` Section 3): docs showed a `:::note ... :::` container syntax; `Callout.astro` doesn't support it. Corrected to the actual `<Callout type="note">` component usage.
- **External linking** (`CONTENT_STANDARDS.md` Section 6): docs claimed `target="_blank" rel="noopener noreferrer"` was enforced on external links. It isn't, anywhere on the live site. Corrected the claim and logged it as a real follow-up (would need a site-wide rehype plugin, not per-article handling).

Also updates `MILESTONES.md`: marks M3.7 complete (first full content pipeline validation, PR #55) and updates C7's content calendar row to reflect PR-open status.

`BRAND.md` was checked and does not need changes, it doesn't specify a path convention.

## Why now
Rather than let the next content session hit the same build break or write to a schema that doesn't exist, corrected the record immediately while the discrepancies were fresh and verified.

## Test plan
- [x] Gitleaks pre-commit hook: no leaks found
- [ ] Richard: review and merge (docs-only, no build/runtime impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)