### PR TITLE
docs(security): add SECURITY.md vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+probl.me is a static site (Astro, deployed via GitHub Pages) with no database, no authentication, and no user data. The attack surface is small, but the CI/CD pipeline still holds things worth protecting: deploy tokens, GitHub Pages permissions, and repository secrets.
+
+## Reporting a Vulnerability
+
+If you find a security issue in this repository, please report it privately rather than opening a public issue.
+
+- **Preferred:** email richard.muffler@gmail.com with a description of the issue and steps to reproduce.
+- Please do not disclose the issue publicly until it has been addressed.
+
+I'll acknowledge reports within a few days and follow up once the issue is resolved or if I need more information.
+
+## Scope
+
+This policy covers the probl.me source repository (`rustymuffler/problme`) and its CI/CD workflows. It does not cover third-party dependencies, if you find a vulnerability in a dependency itself, please report it to that project directly.
+
+## Security Practices
+
+This repository runs a layered security scanning stack (Gitleaks, Semgrep, Trivy, Checkov, and OpenSSF Scorecard) on every push and pull request. See `SECURITY_SCANNING.md` for the full breakdown.


### PR DESCRIPTION
## Summary
Adds a `SECURITY.md` with a vulnerability reporting policy (private email report, scope, pointer to `SECURITY_SCANNING.md`).

Closes one of the two actionable gaps logged in `SCORECARD_IMPROVEMENTS.md`, OpenSSF Scorecard's Security-Policy check currently scores 0/10 because no `SECURITY.md` exists.

## Test plan
- [x] Gitleaks pre-commit hook: no leaks found
- [ ] Richard: review and merge
- [ ] Re-run Scorecard after merge to confirm Security-Policy check improves

🤖 Generated with [Claude Code](https://claude.com/claude-code)