### PR TITLE
fix(security): upload Semgrep SARIF to GitHub code scanning

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,6 +27,9 @@ jobs:
   semgrep:
     name: Semgrep — SAST
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -37,6 +40,23 @@ jobs:
           config: auto
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+
+      # semgrep/semgrep-action@v1 has no SARIF output (only `config` and
+      # `publishToken` inputs), so nothing surfaces in GitHub's code
+      # scanning, which is what Scorecard's SAST check actually looks for.
+      # This runs Semgrep a second time purely to produce that SARIF file;
+      # it does not change the pass/fail gating above.
+      - name: Generate SARIF for code scanning
+        if: always()
+        run: |
+          python3 -m pip install semgrep
+          semgrep scan --config=auto --sarif --output=semgrep.sarif || true
+
+      - name: Upload SARIF to code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@02c5e83432fe5497fd85b873b6c9f16a8578e1d9  # v3
+        with:
+          sarif_file: semgrep.sarif
 
   trivy:
     name: Trivy — Dependency CVE Scan


### PR DESCRIPTION
## Summary
Closes the SAST gap logged in `SCORECARD_IMPROVEMENTS.md`. `semgrep/semgrep-action@v1` is a minimal wrapper (checked its `action.yml` directly: only `config` and `publishToken` inputs), it has no SARIF output at all. Scorecard's SAST check specifically looks for a recognized SAST tool reporting via GitHub code scanning, so it scored 0/10 despite Semgrep genuinely running on every push and PR.

## What changed
Added two steps to the existing `semgrep` job in `security.yml`:
1. A second Semgrep invocation (`semgrep scan --config=auto --sarif --output=semgrep.sarif`) purely to produce SARIF output
2. Upload via `github/codeql-action/upload-sarif`, pinned to the same commit SHA already used in `scorecard.yml`

The original `semgrep/semgrep-action@v1` step is untouched, its gating/reporting behavior doesn't change. The new steps run with `if: always()` alongside it.

## Verification
- `checkov -d .github/ --quiet`: 208 passed, 0 failed
- `/security-review`: no HIGH/MEDIUM findings
- Locally tested the SARIF generation command against `src/content.config.ts`: exit 0, valid SARIF written (the one error I hit locally was a Windows-only console encoding issue, irrelevant on the Ubuntu CI runner)
- Gitleaks pre-commit hook: no leaks found

## Test plan
- [x] Verified locally as above
- [ ] Richard: merge, then re-run Scorecard to confirm SAST moves off 0/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)