### PR TITLE
fix(security): pin semgrep version, update Scorecard tracking

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Generate SARIF for code scanning
         if: always()
         run: |
-          python3 -m pip install semgrep
+          python3 -m pip install semgrep==1.169.0
           semgrep scan --config=auto --sarif --output=semgrep.sarif || true
 
       - name: Upload SARIF to code scanning

--- a/SCORECARD_IMPROVEMENTS.md
+++ b/SCORECARD_IMPROVEMENTS.md
@@ -8,45 +8,45 @@
 ## Latest run
 
 - **Date:** 2026-07-15
-- **Overall score:** 6.9 / 10 (up from 6.1)
-- **Commit analyzed:** `b19443738644a3502e7838aaf4c86fa653a82f81`
+- **Overall score:** 7.0 / 10 (up from 6.1)
+- **Commit analyzed:** `30cbec68fa044019b0e50eb171cda09dd4b0a734`
 - **Method:** `docker run --rm -e GITHUB_AUTH_TOKEN="$(gh auth token)" gcr.io/openssf/scorecard:stable --repo=github.com/rustymuffler/problme --format=json`
 
 ## Full breakdown
 
 | Check | Score | Reason |
 |---|---|---|
-| Pinned-Dependencies | 10/10 | All dependencies are pinned |
 | Token-Permissions | 10/10 | Workflows follow least privilege |
 | Dependency-Update-Tool | 10/10 | Dependabot detected |
 | Dangerous-Workflow | 10/10 | No dangerous workflow patterns |
-| CI-Tests | 10/10 | 15/15 merged PRs checked by CI |
+| CI-Tests | 10/10 | 14/14 merged PRs checked by CI |
 | Maintained | 10/10 | 30 commits in last 90 days |
 | License | 10/10 | License file detected |
 | Binary-Artifacts | 10/10 | No binaries in repo |
-| Security-Policy | 10/10 ⬆ (was 0) | `SECURITY.md` detected, fixed via PR #57 |
+| Security-Policy | 10/10 (was 0) | `SECURITY.md` detected, fixed via PR #57 |
+| Pinned-Dependencies | 9/10 ⬇ (was 10) | Regression, see below, caught and fixed same day |
 | Vulnerabilities | 9/10 | 1 known vulnerability detected (needs triage, see below) |
-| Branch-Protection | 3/10 ⬆ (was 0) | Ruleset "Main Enforcement" now active on `main`: blocks deletion and force-push, requires PR + 7 required status checks. Not "maximal" because `required_approving_review_count` is 0, see below |
-| SAST | 0/10 | Scorecard doesn't recognize a SAST tool running on all commits |
-| Code-Review | 0/10 | 0/11 merged changesets had a human approval |
+| Branch-Protection | 4/10 ⬆ (was 0) | Ruleset "Main Enforcement" active on `main`: blocks deletion and force-push, requires PR + 7 required status checks. Not "maximal" because `required_approving_review_count` is 0, see below |
+| SAST | 1/10 ⬆ (was 0) | PR #60 added Semgrep SARIF upload to code scanning. Scorecard's SAST check looks at recent commit history, not just the latest commit, score should keep climbing as more commits land with SARIF present |
+| Code-Review | 0/10 | 0/10 merged changesets had a human approval |
 | Contributors | 0/10 | 0 contributing orgs (solo project) |
 | CII-Best-Practices | 0/10 | No OpenSSF Best Practices badge |
 | Fuzzing | 0/10 | Not fuzzed |
 | Packaging | N/A (-1) | No packaging workflow (not applicable, static site) |
 | Signed-Releases | N/A (-1) | No releases (not applicable) |
 
-GitHub's own code scanning alerts (populated by `scorecard.yml`'s SARIF upload) mirror this: 6 open (Branch-Protection, Code-Review, CII-Best-Practices, Fuzzing, SAST, Vulnerabilities), 1 fixed (Security-Policy), confirmed 2026-07-15.
-
 ## Actionable before considering public
 
-1. **SAST (0/10).** Semgrep already runs in `security.yml`, but Scorecard's SAST check specifically looks for recognized SAST tool signals tied to commits (e.g., SARIF uploads to GitHub code scanning), not just any step named "semgrep" in a workflow. Fix: have the Semgrep step upload SARIF results to GitHub's code scanning (same pattern as `scorecard.yml`), so Scorecard recognizes it as an active SAST tool.
-2. **Vulnerabilities (9/10).** 1 known vulnerability flagged via OSV. The Scorecard JSON summary doesn't include which one, cross-reference against `SECURITY_SCANNING.md`'s Accepted Risk Log (the `yaml` stack-overflow chain and `@lhci/cli` transitive HIGH finding are the most likely candidates, both already reviewed and accepted as dev-only, zero production attack surface). Needs a follow-up run with more verbose output to confirm which CVE this maps to before calling it fully resolved.
-3. **Branch-Protection, incremental only (3/10).** Enabling "Require branches to be up to date before merging" (`strict_required_status_checks_policy: true` on the ruleset) would likely nudge this up slightly further without needing a second reviewer. The larger jump to a top-tier score requires `required_approving_review_count` ≥ 1, which runs into the same solo-maintainer ceiling as Code-Review below.
+1. **Pinned-Dependencies regression (9/10, was 10/10).** PR #60's SAST fix added `python3 -m pip install semgrep` with no version pin, exactly the kind of thing this whole article/session was about avoiding. Caught on the very next Scorecard run. Fixed same day by pinning to `semgrep==1.169.0`. Full hash-pinning (`--require-hashes` + a requirements file with per-package hashes) would be the theoretically complete fix but is a bigger lift for one point, not pursued right now.
+2. **SAST, still climbing (1/10).** The fix is in (#60), Scorecard just needs more commits with SARIF present in history before it credits "all commits." No further action, just time and normal commit activity.
+3. **Vulnerabilities (9/10).** 1 known vulnerability flagged via OSV. The Scorecard JSON summary doesn't include which one, cross-reference against `SECURITY_SCANNING.md`'s Accepted Risk Log (the `yaml` stack-overflow chain and `@lhci/cli` transitive HIGH finding are the most likely candidates, both already reviewed and accepted as dev-only, zero production attack surface). Needs a follow-up run with more verbose output to confirm which CVE this maps to before calling it fully resolved.
+4. **Branch-Protection, incremental only (4/10).** Enabling "Require branches to be up to date before merging" (`strict_required_status_checks_policy: true` on the ruleset) would likely nudge this up slightly further without needing a second reviewer. The larger jump to a top-tier score requires `required_approving_review_count` ≥ 1, which runs into the same solo-maintainer ceiling as Code-Review below.
 
 ## Resolved
 
 - **Security-Policy (was 0/10, now 10/10).** Fixed via PR #57, `SECURITY.md` added 2026-07-14/15.
-- **Branch-Protection (was 0/10, now 3/10, partial).** Ruleset "Main Enforcement" added 2026-07-14, requires PR + 7 status checks, blocks force-push/deletion. Real, meaningful improvement, not yet "maximal" (see above).
+- **Branch-Protection (was 0/10, now 4/10, partial).** Ruleset "Main Enforcement" added 2026-07-14, requires PR + 7 status checks, blocks force-push/deletion. Real, meaningful improvement, not yet "maximal" (see above).
+- **SAST (was 0/10, now 1/10, in progress).** Fixed via PR #60, will keep climbing as more commits accumulate with SARIF present.
 
 ## Structurally low-fixability, not worth chasing right now
 


### PR DESCRIPTION
## Summary
Re-ran Scorecard after #60 merged.

**Good news:** SAST improved 0 → 1/10, the SARIF upload fix is working. That check looks at recent commit history rather than just the latest commit, so it should keep climbing on its own as more commits land with SARIF present, no further action needed there.

**Regression caught:** Pinned-Dependencies dropped 10 → 9/10 ("dependency not pinned by hash detected"). Cause: #60 added `python3 -m pip install semgrep` with no version pin, exactly the class of thing this whole session (the SHA-pinning article, Dependabot setup) was about avoiding. Fixed here by pinning to `semgrep==1.169.0` (current latest stable).

Overall score: 6.9 → 7.0.

## What changed
- `.github/workflows/security.yml`: pin the new Semgrep SARIF-generation step to an exact version
- `SCORECARD_IMPROVEMENTS.md`: full updated breakdown, including the regression and its same-day fix in the decision log

## Note
Full hash-pinning (`pip install --require-hashes` + a requirements file with per-package hashes) would be the theoretically complete fix, matching the same rigor as the GitHub Actions SHA pins. Not pursued here, it's a bigger lift for one point on a single check. Logged as a known gap if it's ever worth revisiting.

## Verification
- `checkov -d .github/ --quiet`: 208 passed, 0 failed
- Gitleaks pre-commit hook: no leaks found

## Test plan
- [ ] Richard: merge, no functional change expected, just a stricter pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)