### PR TITLE
docs: update THIRD-PARTY-NOTICES.md and credits page for this session

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
 

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -23,6 +23,18 @@ License: MIT
 Copyright: © The Astro Technology Company
 Source: https://github.com/withastro/astro/tree/main/packages/integrations/mdx
 
+**@astrojs/rss** `4.0.18`
+RSS feed generation for Astro — powers `/rss.xml`.
+License: MIT
+Copyright: © The Astro Technology Company
+Source: https://github.com/withastro/astro/tree/main/packages/astro-rss
+
+**@astrojs/sitemap** `3.7.3`
+Sitemap generation for Astro — powers `sitemap-index.xml`.
+License: MIT
+Copyright: © The Astro Technology Company
+Source: https://github.com/withastro/astro/tree/main/packages/sitemap
+
 **tailwindcss** `4.3.1`
 Utility-first CSS framework.
 License: MIT
@@ -86,15 +98,20 @@ site output. Source and license for each action is available at the linked repos
 
 | Action | Version (SHA pinned) | License | Repository |
 |---|---|---|---|
-| `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | MIT | https://github.com/actions/checkout |
-| `actions/setup-node` | `49933ea5288caeca8642d1e84afbd3f7d6820020` | MIT | https://github.com/actions/setup-node |
-| `actions/configure-pages` | `983d7736d9b0ae728b81ab479565c72886d7745b` | MIT | https://github.com/actions/configure-pages |
-| `actions/upload-pages-artifact` | `56afc609e74202658d3ffba0e8f6dda462b719fa` | MIT | https://github.com/actions/upload-pages-artifact |
+| `actions/checkout` | `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` | MIT | https://github.com/actions/checkout |
+| `actions/setup-node` | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` | MIT | https://github.com/actions/setup-node |
+| `actions/configure-pages` | `45bfe0192ca1faeb007ade9deae92b16b8254a0d` | MIT | https://github.com/actions/configure-pages |
+| `actions/upload-pages-artifact` | `fc324d3547104276b827a68afc52ff2a11cc49c9` | MIT | https://github.com/actions/upload-pages-artifact |
 | `actions/deploy-pages` | `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` | MIT | https://github.com/actions/deploy-pages |
-| `lycheeverse/lychee-action` | `82202e5e9c2f4ef1a55a3d02563e1cb6041e5332` | MIT | https://github.com/lycheeverse/lychee-action |
+| `actions/upload-artifact` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` | MIT | https://github.com/actions/upload-artifact |
+| `lycheeverse/lychee-action` | `e7477775783ea5526144ba13e8db5eec57747ce8` | MIT | https://github.com/lycheeverse/lychee-action |
 | `gitleaks/gitleaks-action` | `dcedce43c6f43de0b836d1fe38946645c9c638dc` | MIT | https://github.com/gitleaks/gitleaks-action |
 | `semgrep/semgrep-action` | `713efdd345f3035192eaa63f56867b88e63e4e5d` | MIT | https://github.com/semgrep/semgrep-action |
 | `bridgecrewio/checkov-action` | `fa9edf8f0a491c59a924ea6accd5bdcf07752cff` | Apache-2.0 | https://github.com/bridgecrewio/checkov-action |
+| `ossf/scorecard-action` | `4eaacf0543bb3f2c246792bd56e8cdeffafb205a` | Apache-2.0 | https://github.com/ossf/scorecard-action |
+| `github/codeql-action` | `02c5e83432fe5497fd85b873b6c9f16a8578e1d9` | MIT | https://github.com/github/codeql-action |
+
+Note (2026-07-15): `actions/checkout`, `actions/setup-node`, `actions/configure-pages`, and `actions/upload-pages-artifact` SHAs above were bumped by Dependabot since this file was last updated. `.github/workflows/scorecard.yml` was pinning a stale `actions/checkout` SHA (added after Dependabot's last scan of it, so it was never caught); fixed directly to match the current SHA above.
 
 ---
 
@@ -119,6 +136,12 @@ Link checker (invoked via lychee-action).
 License: MIT
 Copyright: © Matthias Endler and contributors
 Source: https://github.com/lycheeverse/lychee
+
+**Semgrep** `1.169.0`
+Installed directly via pip in `security.yml` to generate SARIF output for GitHub code scanning (separate from the semgrep-action invocation above, which does not support SARIF).
+License: LGPL-2.1-or-later
+Copyright: © Semgrep Inc.
+Source: https://github.com/semgrep/semgrep
 
 ---
 

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -33,7 +33,7 @@ Source: https://github.com/withastro/astro/tree/main/packages/astro-rss
 Sitemap generation for Astro — powers `sitemap-index.xml`.
 License: MIT
 Copyright: © The Astro Technology Company
-Source: https://github.com/withastro/astro/tree/main/packages/sitemap
+Source: https://github.com/withastro/astro/tree/main/packages/integrations/sitemap
 
 **tailwindcss** `4.3.1`
 Utility-first CSS framework.

--- a/src/pages/credits.astro
+++ b/src/pages/credits.astro
@@ -76,9 +76,12 @@ const actionPurposes: Record<string, string> = {
   'actions/upload-pages-artifact': 'CI/CD — uploads the Pages artifact (SHA-pinned).',
   'actions/deploy-pages':          'CI/CD — deploys to GitHub Pages (SHA-pinned).',
   'lycheeverse/lychee-action':     'CI/CD — runs the Lychee link checker (SHA-pinned).',
+  'actions/upload-artifact':       'CI/CD — uploads build artifacts between jobs (SHA-pinned).',
   'gitleaks/gitleaks-action':      'CI/CD — runs Gitleaks on every PR (SHA-pinned).',
   'semgrep/semgrep-action':        'CI/CD — static analysis security scanning (SHA-pinned).',
   'bridgecrewio/checkov-action':   'CI/CD — infrastructure-as-code scanning (SHA-pinned).',
+  'ossf/scorecard-action':         'CI/CD — OpenSSF Scorecard supply-chain checks (SHA-pinned).',
+  'github/codeql-action':          'CI/CD — uploads SARIF results to code scanning (SHA-pinned).',
 };
 
 function parseActionsTable(text: string): Dep[] {
@@ -105,14 +108,18 @@ const fonts     = parseFonts(raw);
 const actions   = parseActionsTable(raw);
 const lychee    = parseLychee(raw);
 
-const frameworkNames = new Set(['astro', '@astrojs/mdx', 'tailwindcss', '@tailwindcss/vite']);
+const frameworkNames = new Set(['astro', '@astrojs/mdx', '@astrojs/rss', '@astrojs/sitemap', 'tailwindcss', '@tailwindcss/vite']);
 const buildNpmNames  = new Set(['@astrojs/check', 'typescript', '@playwright/test', '@axe-core/playwright', '@lhci/cli']);
-const secBinNames    = new Set(['Gitleaks', 'Trivy']);
+const secBinNames    = new Set(['Gitleaks', 'Trivy', 'Semgrep']);
 const buildActNames  = new Set([
   'actions/checkout', 'actions/setup-node', 'actions/configure-pages',
-  'actions/upload-pages-artifact', 'actions/deploy-pages', 'lycheeverse/lychee-action',
+  'actions/upload-pages-artifact', 'actions/deploy-pages', 'actions/upload-artifact',
+  'lycheeverse/lychee-action',
 ]);
-const secActNames    = new Set(['gitleaks/gitleaks-action', 'semgrep/semgrep-action', 'bridgecrewio/checkov-action']);
+const secActNames    = new Set([
+  'gitleaks/gitleaks-action', 'semgrep/semgrep-action', 'bridgecrewio/checkov-action',
+  'ossf/scorecard-action', 'github/codeql-action',
+]);
 
 // Manual entry — not in THIRD-PARTY-NOTICES.md (see AGENTS.md §Security)
 const spectraEntry: Dep = {


### PR DESCRIPTION
## Summary
Answers "do we need to update third-party notices and the credits page": yes, on several real fronts, not just cosmetic.

### THIRD-PARTY-NOTICES.md
- Updated 4 Dependabot-bumped Action SHAs (`checkout`, `setup-node`, `configure-pages`, `upload-pages-artifact`), which had drifted out of sync with what's actually pinned in the workflows
- Added 3 new actions from this session: `ossf/scorecard-action`, `actions/upload-artifact`, `github/codeql-action`
- Added Semgrep as its own "Security Scanning Binaries" entry, it's now also pip-installed directly (for SARIF output), a separate invocation path from `semgrep-action`. License verified via `pip show semgrep` (`LGPL-2.1-or-later`), not assumed
- Added `@astrojs/rss` and `@astrojs/sitemap`, real `package.json` dependencies that were never listed here at all, a pre-existing gap, fixed while in the file

### credits.astro
Found a real bug while verifying: this page renders from `THIRD-PARTY-NOTICES.md` via hardcoded name allow-lists per bucket. Without updating those lists, all the new entries above would have been silently invisible on the live page despite being correctly documented in the markdown. Fixed and confirmed visually, every new entry now renders (Framework & Runtime: 6, Build & Test Tooling: 13, Security & Quality: 9).

### scorecard.yml
Also fixed a stale `actions/checkout` SHA, that workflow was added after Dependabot's last scan, so it was never caught and bumped like the others.

### Note on verification
Hit a local-only snag while checking this: `core.autocrlf=true` on this Windows dev machine converts the working copy to CRLF, which broke the credits page's newline-anchored regex parser *locally*. Confirmed via `git show HEAD:THIRD-PARTY-NOTICES.md | file -` that what's actually committed (and what CI's Linux runners check out) is plain LF, unaffected. Not a production bug, worked around locally to actually verify the rendering.

## Verification
- `checkov -d .github/ --quiet`: 208 passed, 0 failed
- `npm run build`: passes
- `/credits` page visually confirmed rendering all new entries with correct SHAs, licenses, and descriptions
- Gitleaks pre-commit hook: no leaks found

## Test plan
- [ ] Richard: review and merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)