### PR TITLE
fix(content): set SHA-pinning article date to its actual publish date

### DIFF
--- a/src/content/posts/pin-github-actions-dependabot/index.mdx
+++ b/src/content/posts/pin-github-actions-dependabot/index.mdx
@@ -3,7 +3,7 @@ title: "Why I SHA-Pin Every GitHub Action (and Automate Updates)"
 description: "I lock every GitHub Action to its commit SHA instead of a mutable tag, then let Dependabot keep the pins current. Here's why a tag alone isn't enough."
 category: tech-tools
 tags: ["github-actions", "supply-chain-security", "dependabot", "ci-cd", "openssf-scorecard"]
-date: 2026-07-17
+date: 2026-07-15
 readTime: "9 min"
 heroImage: /assets/posts/pin-github-actions-dependabot/hero.png
 imageCredit: "AI-generated with Claude"


### PR DESCRIPTION
## Summary

The "Why I SHA-Pin Every GitHub Action" article went live when [PR #55](https://github.com/rustymuffler/problme/pull/55) merged on **2026-07-15** (00:38), but its frontmatter `date` carried the planned publish date of **2026-07-17** — so the live site has been showing a future-dated post since merge. This sets the date to the day it was actually published.

One-line frontmatter change per CONTENT_STANDARDS.md §9 (minor edit, `fix/` branch, no re-review needed). Build verified.

Related: the broader "future-dated posts publish on merge" gap is being handled in a separate session (background task from the SEO review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)