### PR TITLE
docs(pm): Umami analytics prep — fork created, blockers and Decision 8 updated

### DIFF
--- a/BLOCKERS.md
+++ b/BLOCKERS.md
@@ -1,7 +1,7 @@
 # probl.me — Active Blockers
 
 > Living log maintained by the PM Agent. Update when blockers are found or resolved.
-> Last updated: 2026-06-25 (Step 4 a11y audit)
+> Last updated: 2026-07-15 (Umami analytics prep — fork created, blockers 5–7 refreshed)
 
 ---
 
@@ -13,9 +13,9 @@
 | ~~2~~ | ~~probl.me DNS: CNAME needs to point to rustymuffler.github.io~~ | ~~M1.14~~ | Richard | 2026-06-22 | ✅ Resolved |
 | ~~3~~ | ~~Aikido plugin not yet installed in Claude Code~~ | ~~SECURITY_SCANNING.md — Tool 1 (Aikido)~~ | Richard | 2026-06-22 | ✅ Resolved |
 | ~~4~~ | ~~Semgrep App Token not yet configured~~ | ~~SECURITY_SCANNING.md — Tool 2 + CI~~ | Richard | 2026-06-22 | ✅ Resolved |
-| 5 | Supabase account + project not yet created | M3.17 — Umami analytics database | Richard | 2026-06-22 | ⬜ Not started |
-| 6 | Vercel account not yet created | M3.19 — Umami analytics hosting | Richard | 2026-06-22 | ⬜ Not started |
-| 7 | Umami data-website-id not yet generated | M3.22 — Tracking script in Layout.astro | Richard | 2026-06-22 | 🔑 Waiting on M3.21 (Umami deploy) |
+| 5 | Supabase account + project not yet created | M3.17 — Umami analytics database | Richard | 2026-06-22 | ⬜ Not started — next action: create free account, note `DATABASE_URL` + `DIRECT_DATABASE_URL` |
+| 6 | Vercel account not yet created | M3.19 — Umami analytics hosting | Richard | 2026-06-22 | ⬜ Not started — fork to import is ready: `rustymuffler/umami` (created 2026-07-15, no code changes needed; see Decision 8 addendum) |
+| 7 | Umami data-website-id not yet generated | M3.22 — Tracking script in Layout.astro | Richard | 2026-06-22 | 🔑 Waiting on M3.21 (Umami deploy) — once available, Developer Agent adds the script tag to `Layout.astro` via PR |
 | ~~8~~ | ~~Community badge contrast fails WCAG AA~~ | ~~`src/pages/credits.astro`~~ | Richard | 2026-06-25 | ✅ Resolved |
 
 ---

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -137,6 +137,8 @@
 
 **Impact:** Monthly retrospectives have access to real reader engagement data. The `data-website-id` and Vercel Umami URL are stored as environment variables or build-time constants — never hardcoded without review. The Umami tracking script is the one approved third-party script in `<head>` per the project invariants. The setup process itself is a blog article candidate in the Tech Stack + Tools category.
 
+**Addendum (2026-07-15):** Setup step 2's `schema.prisma` modification is no longer needed. Upstream Umami now supports `DIRECT_DATABASE_URL` natively — its `scripts/check-db.js` uses that variable for Prisma migrations when set, which is exactly what the Supabase workaround provided. The fork was created as planned (`rustymuffler/umami`, for Vercel to deploy from) but carries **no code changes**; keeping it unmodified means upstream updates can be pulled cleanly. Steps 1 and 3–8 are unchanged: set both `DATABASE_URL` (pooled) and `DIRECT_DATABASE_URL` (direct) as Vercel environment variables in step 4.
+
 ---
 
 ## Decision 9: Dependabot Vulnerability Alerts — No Action (June 2026)


### PR DESCRIPTION
## Summary

Prep work for the Umami analytics setup (Decision 8):

- **Fork created:** [`rustymuffler/umami`](https://github.com/rustymuffler/umami) is ready for the Vercel import.
- **Decision 8 addendum:** the planned `schema.prisma` modification is obsolete — upstream Umami now supports `DIRECT_DATABASE_URL` natively (its `scripts/check-db.js` uses it for Prisma migrations when set). The fork carries no code changes, so upstream updates can be pulled cleanly.
- **Blockers 5–7 refreshed** with concrete next actions.

## Remaining steps (Richard)

1. Create a Supabase free account + project; note `DATABASE_URL` (pooled) and `DIRECT_DATABASE_URL` (direct)
2. Create a Vercel free account; import `rustymuffler/umami`
3. Set both database URLs as Vercel environment variables; deploy
4. Add probl.me as a website in the Umami dashboard; copy the `data-website-id`
5. Hand the Vercel app URL + website-id to a code session — the tracking script goes into `Layout.astro` via PR (pre-approved third-party script per project invariants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)