### PR TITLE
feat(analytics): add Umami tracking script to Layout

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -26,6 +26,10 @@ const isAbout = pathname.startsWith('/about');
 
 const siteUrl = SITE_URL;
 
+// Umami analytics (Decision 8) — build-time constants, not secrets.
+const UMAMI_SCRIPT_URL = 'https://problme-umami.vercel.app/script.js';
+const UMAMI_WEBSITE_ID = '774d4193-5d49-48c4-9214-e957b38c6067';
+
 // WebSite schema on the homepage; pages pass their own schemas via jsonLd.
 const schemas = [...(isHome ? [websiteSchema] : []), ...jsonLd];
 ---
@@ -70,6 +74,19 @@ const schemas = [...(isHome ? [websiteSchema] : []), ...jsonLd];
       is:inline
     />
   ))}
+
+  <!-- Umami analytics: self-hosted, cookie-free, GDPR-compliant. The one
+       pre-approved third-party script (DECISIONS.md Decision 8).
+       data-domains limits tracking to production, so localhost previews
+       and any forks never pollute the stats. Neither value is a secret;
+       the website id is visible in page source by design. -->
+  <script
+    is:inline
+    async
+    src={UMAMI_SCRIPT_URL}
+    data-website-id={UMAMI_WEBSITE_ID}
+    data-domains="probl.me"
+  ></script>
 
   <!-- Fonts: Bunny Fonts (privacy-friendly, no IP logging) -->
   <link rel="preconnect" href="https://fonts.bunny.net" crossorigin />


### PR DESCRIPTION
## Summary

Final step of the Umami analytics setup (Decision 8): adds the tracking script to `Layout.astro` so every page reports to the self-hosted Umami instance at `problme-umami.vercel.app` (Vercel + Supabase, both free tier).

- **Pre-approved script**: this is the one third-party script allowed in `<head>` per project invariants (DECISIONS.md Decision 8)
- **`data-domains="probl.me"`**: tracking only fires on the production domain — localhost previews, CI builds, and forks send nothing
- **Not secrets**: the script URL and website id are public by design (visible in page source); stored as build-time constants
- Cookie-free and GDPR-compliant — no cookie banner needed

## Verification

- Tag present on all 24 built pages with correct website id and domain guard
- Script URL verified live: 200, `application/javascript` (Umami tracker, 4.6 KB)
- Full end-to-end check happens after merge: open https://probl.me, then watch the pageview appear in the Umami dashboard's Realtime view

Resolves BLOCKERS.md #5–7 (statuses updated in PR #68).

🤖 Generated with [Claude Code](https://claude.com/claude-code)