### PR TITLE
feat(credits): add Umami to credits page and third-party notices

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -47,6 +47,12 @@ License: MIT
 Copyright: © Tailwind Labs Inc.
 Source: https://github.com/tailwindlabs/tailwindcss
 
+**rehype-external-links** `3.0.0`
+Rehype plugin that opens external links in a new tab site-wide.
+License: MIT
+Copyright: © Titus Wormer
+Source: https://github.com/rehypejs/rehype-external-links
+
 ---
 
 ### Build tooling and type checking
@@ -142,6 +148,20 @@ Installed directly via pip in `security.yml` to generate SARIF output for GitHub
 License: LGPL-2.1-or-later
 Copyright: © Semgrep Inc.
 Source: https://github.com/semgrep/semgrep
+
+---
+
+## Self-Hosted Analytics
+
+Runs on its own infrastructure (Vercel + Supabase), separate from this repository.
+The tracking script it serves is the one approved third-party script on the site
+(see DECISIONS.md Decision 8).
+
+**umami** `3.2.0`
+Privacy-first, cookie-free analytics — self-hosted on Vercel with a Supabase Postgres database (both free tier).
+License: MIT
+Copyright: © Umami Software, Inc.
+Source: https://github.com/umami-software/umami
 
 ---
 

--- a/src/pages/credits.astro
+++ b/src/pages/credits.astro
@@ -13,8 +13,11 @@ interface Dep {
 
 interface BadgeStyle { color: string; bg: string; }
 
-// Read THIRD-PARTY-NOTICES.md at build time
-const raw = readFileSync(resolve('THIRD-PARTY-NOTICES.md'), 'utf-8');
+// Read THIRD-PARTY-NOTICES.md at build time. Normalize CRLF → LF: on
+// Windows working trees git's autocrlf checks the file out with CRLF,
+// which silently broke every \n-based parser below (empty credits page
+// in local builds; CI checkouts are LF so production was unaffected).
+const raw = readFileSync(resolve('THIRD-PARTY-NOTICES.md'), 'utf-8').replace(/\r\n/g, '\n');
 
 // Parse **name** `version` style blocks (npm packages + security binaries)
 function parseVersionedBlocks(text: string): Dep[] {
@@ -108,7 +111,7 @@ const fonts     = parseFonts(raw);
 const actions   = parseActionsTable(raw);
 const lychee    = parseLychee(raw);
 
-const frameworkNames = new Set(['astro', '@astrojs/mdx', '@astrojs/rss', '@astrojs/sitemap', 'tailwindcss', '@tailwindcss/vite']);
+const frameworkNames = new Set(['astro', '@astrojs/mdx', '@astrojs/rss', '@astrojs/sitemap', 'tailwindcss', '@tailwindcss/vite', 'rehype-external-links']);
 const buildNpmNames  = new Set(['@astrojs/check', 'typescript', '@playwright/test', '@axe-core/playwright', '@lhci/cli']);
 const secBinNames    = new Set(['Gitleaks', 'Trivy', 'Semgrep']);
 const buildActNames  = new Set([
@@ -141,12 +144,16 @@ const securityQuality: Dep[]  = [
   ...versioned.filter(d => secBinNames.has(d.name)),
   ...actions.filter(d => secActNames.has(d.name)),
 ];
+// Umami's row carries the Vercel + Supabase mention in its purpose text,
+// mirroring how Bunny Fonts is credited inside the font entries.
+const analytics: Dep[]        = versioned.filter(d => d.name === 'umami');
 
 interface Bucket { label: string; deps: Dep[]; hue: string; }
 const buckets: Bucket[] = [
   { label: 'Framework & Runtime',  deps: framework,       hue: 'var(--color-amber)' },
   { label: 'Build & Test Tooling', deps: buildTest,       hue: 'var(--color-amber)' },
   { label: 'Security & Quality',   deps: securityQuality, hue: 'var(--color-terracotta)' },
+  { label: 'Analytics',            deps: analytics,       hue: 'var(--color-amber)' },
   { label: 'Fonts',                deps: fonts,           hue: 'var(--color-olive)' },
 ];
 


### PR DESCRIPTION
## Summary

Adds Umami to the credits page per the agreed pattern: the open-source project gets a proper row, and Vercel + Supabase are acknowledged inside its purpose text — the same treatment Bunny Fonts gets in the font entries.

- **New "Analytics" bucket** on `/credits` with one row: `umami 3.2.0` (MIT) — *"Privacy-first, cookie-free analytics — self-hosted on Vercel with a Supabase Postgres database (both free tier)."*
- **Backfill**: `rehype-external-links 3.0.0` added to THIRD-PARTY-NOTICES.md and the Framework & Runtime bucket — it was installed in #66's follow-up without the notices entry the file requires for every new npm dependency.
- **Bug fix found while verifying**: the credits parser missed everything on Windows working trees because git `autocrlf` checks THIRD-PARTY-NOTICES.md out with CRLF and the regexes only matched `\n` — local builds rendered an empty credits page. Now normalized to LF before parsing. CI checkouts are LF, so the production page was never affected.

## Verification

Local build + preview: Analytics bucket renders with the Umami row and correct MIT badge; Framework & Runtime shows 7 entries including rehype-external-links; all pre-existing buckets unchanged (13 build/test, 9 security, 2 fonts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)