### PR TITLE
fix(deps): patch remaining HIGH CVEs flagged by OpenSSF Scorecard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3760,9 +3760,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3816,9 +3816,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10476,9 +10476,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.20",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
-      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -11719,19 +11719,6 @@
       "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/yaml-language-server/node_modules/yaml": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.3",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,11 @@
     "svgo": "^4.0.2",
     "fast-xml-parser": "^5.10.1",
     "postcss": "^8.5.18",
-    "nanoid": "^3.3.18"
+    "nanoid": "^3.3.18",
+    "body-parser": "^1.20.6",
+    "brace-expansion": "^1.1.18",
+    "tar": "^7.5.22",
+    "yaml": "^2.9.0",
+    "fast-uri": "^3.1.5"
   }
 }


### PR DESCRIPTION
## Summary
- Adds npm `overrides` for `body-parser`, `brace-expansion`, `tar`, `yaml`, and `fast-uri` to resolve 6 of the 7 GHSA advisories flagged by the OpenSSF Scorecard Vulnerabilities check (score was 3/10, "7 existing vulnerabilities detected").
- All are transitive dev-dependencies (Lighthouse CI, Astro tooling) — not in the deployed runtime bundle.
- `extract-zip`'s symlink-traversal advisory ([GHSA-jmr9-qjv8-65gv](https://github.com/advisories/GHSA-jmr9-qjv8-65gv)) has no patched release upstream (still at 2.0.1, last published 2020) and can't be fixed without a major downgrade of `@lhci/cli`, so it's left unresolved — worth revisiting once a fix ships.

Fixes applied:
| Package | Was | Now | Advisory |
|---|---|---|---|
| body-parser | 1.20.5 | ^1.20.6 | GHSA-v422-hmwv-36x6 |
| brace-expansion | 1.1.15 | ^1.1.18 | GHSA-3jxr-9vmj-r5cp, GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895 |
| tar | 7.5.20 | ^7.5.22 | GHSA-r292-9mhp-454m |
| yaml | 2.7.1 | ^2.9.0 | GHSA-48c2-rrv3-qjmp |
| fast-uri | 3.1.4 | ^3.1.5 | GHSA-7p8r-x3mc-p8w7 (surfaced separately during this fix) |

## Test plan
- [x] `npm install` succeeds with new overrides
- [x] `npm run build` succeeds (38 pages built)
- [x] Packages scanned with `rl-protect` before install (all passed)
- [ ] CI checks pass (Trivy, Semgrep, Gitleaks, Checkov, Build, Lighthouse, Link checker)

Per `AGENTS.md`'s infra-PR rule, this needs a second look before merge — it's a dependency-only change, not the agent that wrote it declaring it safe alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)